### PR TITLE
Makefile: don't pre-compress manpages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ DOCDIR = $(PREFIX)/share/doc/$(PN)-$(VERSION)
 MANDIR = $(PREFIX)/share/man/man8
 INITDIR_SYSTEMD = /usr/lib/systemd/user
 SKELDIR = $(PREFIX)/share/$(PN)
+BASHDIR = $(PREFIX)/share/bash-completion/completions
 ZSHDIR = $(PREFIX)/share/zsh/site-functions
 
 INSTALL = install -p
@@ -28,6 +29,8 @@ install-bin:
 	$(INSTALL_PROGRAM) common/$(PN) "$(DESTDIR)$(BINDIR)/$(PN)"
 	$(INSTALL_DATA) common/$(PN).skel "$(DESTDIR)$(SKELDIR)/$(PN).skel"
 
+	$(INSTALL_DIR) "$(DESTDIR)$(BASHDIR)"
+	$(INSTALL_DATA) common/bash-completion "$(DESTDIR)$(BASHDIR)/modprobed-db"
 	$(INSTALL_DIR) "$(DESTDIR)$(ZSHDIR)"
 	$(INSTALL_DATA) common/zsh-completion "$(DESTDIR)$(ZSHDIR)/_modprobed-db"
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ install-bin:
 
 	$(INSTALL_DIR) "$(DESTDIR)$(ZSHDIR)"
 	$(INSTALL_DATA) common/zsh-completion "$(DESTDIR)$(ZSHDIR)/_modprobed-db"
-	
+
 	$(INSTALL_DIR) "$(DESTDIR)$(INITDIR_SYSTEMD)"
 	$(INSTALL_DATA) init/modprobed-db.service "$(DESTDIR)$(INITDIR_SYSTEMD)/modprobed-db.service"
 	$(INSTALL_DATA) init/modprobed-db.timer "$(DESTDIR)$(INITDIR_SYSTEMD)/modprobed-db.timer"
@@ -39,7 +39,6 @@ install-man:
 	$(Q)echo -e '\033[1;32mInstalling manpage...\033[0m'
 	$(INSTALL_DIR) "$(DESTDIR)$(MANDIR)"
 	$(INSTALL_DATA) doc/$(PN).8 "$(DESTDIR)$(MANDIR)/$(PN).8"
-	gzip -9 "$(DESTDIR)$(MANDIR)/$(PN).8"
 
 install: install-bin install-man
 

--- a/common/bash-completion
+++ b/common/bash-completion
@@ -1,0 +1,11 @@
+_modprobed_db() {
+    local cur prev words cword
+    _init_completion || return
+
+    case $COMP_CWORD in
+        1)
+            COMPREPLY=( $(compgen -W "list store storesilent debug recall rebuild" -- $cur) );;
+    esac
+}
+
+complete -F _modprobed_db modprobed-db


### PR DESCRIPTION
The man program supports a variety of compressed manpage formats, as well as uncompressed manpages. It is standard practice for software to decline to make assumptions about what individual redistributors want to do.

Various distros have different policies about how to handle this:

- Arch Linux compresses manpages that haven't yet been compressed, conditional on a tuneable site option "zipman"

- Alpine compresses manpages that haven't yet been compressed

- debian automatically compresses manpages that haven't yet been compressed with dh_compress

- fedora discards all compression you do and recompresses with brp-compress

- Gentoo issues a QA warning if it is already compressed, and if uncompressed will allow you to configure via:
  - PORTAGE_COMPRESS, which compression method to use (defaulting to bzip2, not gzip)
  - PORTAGE_COMPRESS_EXCLUDE_SUFFIXES, whether to compress at all

- voidlinux finds all manpages installed with compression, and uncompresses them

In short, no one actually wants packages to install compressed manpages directly. Furthermore, the gzip program isn't reproducible by default, but distros that offer optional or mandatory (re)compression of man pages pass the requisite options to make it reproducible.